### PR TITLE
Ignore doc/tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .mypy_cache
 __pycache__
-
+/doc/tags


### PR DESCRIPTION
I added `doc/tags` to ignore as in [vim-vsnip](https://github.com/hrsh7th/vim-vsnip/blob/master/.gitignore). This is useful if you have a local git repo.