### PR TITLE
fix: deoplete source syntax error

### DIFF
--- a/rplugin/python3/deoplete/source/vsnip.py
+++ b/rplugin/python3/deoplete/source/vsnip.py
@@ -28,10 +28,10 @@ class Source(Base):
                         'word': prefix,
                         'abbr': prefix,
                         'menu': 'Snippet',
-                        'info': snippet['label']
+                        'info': snippet['label'],
                         'user_data': json.dumps({
                           'vsnip_integ': {
-                            'snippet': l:snippet.body
+                            'snippet': snippet['body']
                           }
                         })
                     }


### PR DESCRIPTION
Sorry, I do not yet fully understand this plugin.
But I know the syntax of vimscript and python are slightly different...