### PR TITLE
Fixes mucomplete completion list

### DIFF
--- a/autoload/vsnip_integ/integration/mucomplete.vim
+++ b/autoload/vsnip_integ/integration/mucomplete.vim
@@ -20,8 +20,10 @@ function! vsnip_integ#integration#mucomplete#complete() abort
   endif
 
   let l:candidates = vsnip#get_complete_items(bufnr('%'))
+  let l:match = map(l:candidates, { _, val -> (l:keyword == val["word"][0:strlen(l:keyword)-1]) ? val : ''})
+  
   if !empty(l:candidates)
-    call complete(col('.') - strlen(l:keyword), l:candidates)
+    call complete(col('.') - strlen(l:keyword), l:match)
   endif
 
   return ''


### PR DESCRIPTION
filters out all the snippets that have a prefix that does not match a the keyword. Fixes #37