### PR TITLE
Stop working with nvim-compe

### DIFF
--- a/autoload/vsnip_integ.vim
+++ b/autoload/vsnip_integ.vim
@@ -78,6 +78,13 @@ function! vsnip_integ#on_complete_done(completed_item) abort
       endif
     endif
 
+    " disable `on_complete_done` for nvim-compe.
+    if index(l:context.sources, 'compe') >= 0
+      if vsnip_integ#detection#exists('compe')
+        return
+      endif
+    endif
+
     if s:stop_complete_done | return | endif
     let s:stop_complete_done = v:true
     call timer_start(0, { -> execute('let s:stop_complete_done = v:false') })

--- a/autoload/vsnip_integ/detection.vim
+++ b/autoload/vsnip_integ/detection.vim
@@ -8,6 +8,7 @@ let s:definition = {
 \   'mucomplete': { -> exists('g:loaded_mucomplete') },
 \   'deoplete_lsp': { -> s:runtimepath('lua/deoplete.lua') },
 \   'completion_nvim': { -> exists('g:loaded_completion') },
+\   'compe': { -> exists('g:loaded_compe') },
 \ }
 
 let s:cache = {}


### PR DESCRIPTION
nvim-compe will implement expansion by itself. https://github.com/hrsh7th/nvim-compe/pull/97

So vim-vsnip-integ is not required anymore but I add this to stop working explicitly for if the user installs both.
