### PR TITLE
Remove nvimlsp from detection.vim

### DIFF
--- a/autoload/vsnip_integ/detection.vim
+++ b/autoload/vsnip_integ/detection.vim
@@ -1,6 +1,5 @@
 let s:definition = {
 \   'vimlsp': { -> exists('g:lsp_loaded') },
-\   'nvimlsp': { -> s:runtimepath('lua/vim/lsp.lua') },
 \   'lsc': { -> exists('g:loaded_lsc') },
 \   'lcn': { -> exists('g:LanguageClient_serverCommands') },
 \   'lamp': { -> exists('g:loaded_lamp') },


### PR DESCRIPTION
When I use this plugin with neovim builtin lsp, I got the error `E117: 未知の関数です: vsnip_integ#integration#nvimlsp#attach` because this function isn't exists

I think this detection isn't needed already