### PR TITLE
Catch up with the latest ddc-nvim-lsp

### DIFF
--- a/autoload/vsnip_integ.vim
+++ b/autoload/vsnip_integ.vim
@@ -239,6 +239,12 @@ function! s:extract_user_data(completed_item) abort
     let l:user_data = a:completed_item.user_data
     if type(l:user_data) == type('')
       let l:user_data = json_decode(l:user_data)
+    elseif s:has_key(l:user_data, 'lspitem')
+      " ddc-nvim-lsp
+      return {
+      \   'sources': ['ddc'],
+      \   'completion_item': json_decode(l:user_data.lspitem)
+      \ }
     endif
 
     " Support dict only.


### PR DESCRIPTION
`user_data` which ddc-nvim-lsp sends has a structure like below now.
https://github.com/Shougo/ddc-nvim-lsp/blob/8c67080b27a19978d219e869eaf6e5c523aaf9ec/denops/ddc-sources/nvimlsp.ts#L162-L164