### PR TITLE
Use Position.vim_to_lsp() to support multibyte characters

### DIFF
--- a/autoload/vsnip_integ.vim
+++ b/autoload/vsnip_integ.vim
@@ -1,4 +1,5 @@
 let s:TextEdit = vital#vsnip#import('VS.LSP.TextEdit')
+let s:Position = vital#vsnip#import('VS.LSP.Position')
 
 let s:stop_complete_done = v:false
 let s:stop_complete_done_after = v:false
@@ -143,9 +144,10 @@ function! s:get_expand_text(context) abort
   if l:completion_item isnot# v:null
     let l:word = l:completed_item.word
     if has_key(l:completion_item, 'textEdit') && type(l:completion_item.textEdit) == type({})
+      let l:lsp_pos = s:Position.vim_to_lsp('%', [l:done_pos[1], l:done_pos[2] + l:done_pos[3]])
       let l:text_edit = copy(l:completion_item.textEdit)
-      let l:text_edit.range.start.character = min([l:done_pos[2] + l:done_pos[3] - strchars(l:word) - 1, l:text_edit.range.start.character])
-      let l:text_edit.range.end.character = max([(l:done_pos[2] + l:done_pos[3]) - 1, l:text_edit.range.end.character])
+      let l:text_edit.range.start.character = min([l:lsp_pos['character'] - strchars(l:word), l:text_edit.range.start.character])
+      let l:text_edit.range.end.character = max([l:lsp_pos['character'], l:text_edit.range.end.character])
       let l:text_edit_before = strcharpart(l:done_line, 0, l:completion_item.textEdit.range.start.character)
       let l:text_edit_after = strcharpart(l:done_line, l:completion_item.textEdit.range.end.character, strchars(l:done_line) - l:completion_item.textEdit.range.end.character)
       if l:done_line !=# l:text_edit_before . s:trim_unmeaning_tabstop(l:completion_item.textEdit.newText) . l:text_edit_after
@@ -194,6 +196,7 @@ function! s:remove_completed_text(context) abort
   let l:completed_item = a:context.completed_item
   let l:completion_item = get(a:context, 'completion_item', v:null)
   let l:complete_position = get(a:context, 'complete_position', v:null)
+  let l:lsp_pos = s:Position.vim_to_lsp('%', [l:done_pos[1], l:done_pos[2] + l:done_pos[3]])
 
   " Remove trigger character.
   call setline('.', l:done_line)
@@ -201,13 +204,10 @@ function! s:remove_completed_text(context) abort
   " Create range to remove.
   let l:range = {
         \   'start': {
-        \     'line': l:done_pos[1] - 1,
-        \     'character': (l:done_pos[2] + l:done_pos[3]) - strchars(l:completed_item.word) - 1
+        \     'line': l:lsp_pos['line'],
+        \     'character': l:lsp_pos['character'] - strchars(l:completed_item.word)
         \   },
-        \   'end': {
-        \     'line': l:done_pos[1] - 1,
-        \     'character': (l:done_pos[2] + l:done_pos[3]) - 1
-        \   }
+        \   'end': l:lsp_pos
         \ }
 
   " Support `textEdit` range for LSP CompletionItem.
@@ -221,7 +221,7 @@ function! s:remove_completed_text(context) abort
   \   'range': l:range,
   \   'newText': ''
   \ }])
-  call cursor([l:range.start.line + 1, l:range.start.character + 1])
+  call cursor(s:Position.lsp_to_vim('%', l:range.start))
 endfunction
 
 "

--- a/autoload/vsnip_integ.vim
+++ b/autoload/vsnip_integ.vim
@@ -144,10 +144,10 @@ function! s:get_expand_text(context) abort
   if l:completion_item isnot# v:null
     let l:word = l:completed_item.word
     if has_key(l:completion_item, 'textEdit') && type(l:completion_item.textEdit) == type({})
-      let l:lsp_pos = s:Position.vim_to_lsp('%', [l:done_pos[1], l:done_pos[2] + l:done_pos[3]])
+      let l:lsp_done_pos = s:Position.vim_to_lsp('%', [l:done_pos[1], l:done_pos[2] + l:done_pos[3]])
       let l:text_edit = copy(l:completion_item.textEdit)
-      let l:text_edit.range.start.character = min([l:lsp_pos['character'] - strchars(l:word), l:text_edit.range.start.character])
-      let l:text_edit.range.end.character = max([l:lsp_pos['character'], l:text_edit.range.end.character])
+      let l:text_edit.range.start.character = min([l:lsp_done_pos['character'] - strchars(l:word), l:text_edit.range.start.character])
+      let l:text_edit.range.end.character = max([l:lsp_done_pos['character'], l:text_edit.range.end.character])
       let l:text_edit_before = strcharpart(l:done_line, 0, l:completion_item.textEdit.range.start.character)
       let l:text_edit_after = strcharpart(l:done_line, l:completion_item.textEdit.range.end.character, strchars(l:done_line) - l:completion_item.textEdit.range.end.character)
       if l:done_line !=# l:text_edit_before . s:trim_unmeaning_tabstop(l:completion_item.textEdit.newText) . l:text_edit_after
@@ -196,7 +196,7 @@ function! s:remove_completed_text(context) abort
   let l:completed_item = a:context.completed_item
   let l:completion_item = get(a:context, 'completion_item', v:null)
   let l:complete_position = get(a:context, 'complete_position', v:null)
-  let l:lsp_pos = s:Position.vim_to_lsp('%', [l:done_pos[1], l:done_pos[2] + l:done_pos[3]])
+  let l:lsp_done_pos = s:Position.vim_to_lsp('%', [l:done_pos[1], l:done_pos[2] + l:done_pos[3]])
 
   " Remove trigger character.
   call setline('.', l:done_line)
@@ -204,10 +204,10 @@ function! s:remove_completed_text(context) abort
   " Create range to remove.
   let l:range = {
         \   'start': {
-        \     'line': l:lsp_pos['line'],
-        \     'character': l:lsp_pos['character'] - strchars(l:completed_item.word)
+        \     'line': l:lsp_done_pos['line'],
+        \     'character': l:lsp_done_pos['character'] - strchars(l:completed_item.word)
         \   },
-        \   'end': l:lsp_pos
+        \   'end': l:lsp_done_pos
         \ }
 
   " Support `textEdit` range for LSP CompletionItem.


### PR DESCRIPTION
Position information from Vim must be converted to lsp position like vsnip's snippets expansion.
By this PR, textEdit is properly applied if multibyte character is in front of the cursor.