### PR TITLE
Update description of 'dup' for ddc.vim

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,5 +57,5 @@ This plugin provides some plugins integration.
 #### [ddc.vim](https://github.com/Shougo/ddc.vim)
 - Snippet completion.
 - ddc.vim remove duplicated keyword by default.  
-If you want to list up both of them, please add `'dup': v:true` .
+If you want to list up both of them, please add `'dup': 'keep'` .
 


### PR DESCRIPTION
The type of `dup` was changed to string.
[:h ddc-source-option-dup](https://github.com/Shougo/ddc.vim/blob/main/doc/ddc.txt#L550)