### PR TITLE
Prevent overwriting user-defined supported completion function

### DIFF
--- a/autoload/vsnip_integ/integration/vimlsp.vim
+++ b/autoload/vsnip_integ/integration/vimlsp.vim
@@ -3,7 +3,11 @@
 "
 function! vsnip_integ#integration#vimlsp#attach() abort
   let g:lsp_text_edit_enabled = v:true
+
+  " save existing value because it may be user-defined.
+  let s:existing_capabilities_function = get(g:, lsp_get_supported_capabilities)
   let g:lsp_get_supported_capabilities = [function('s:get_supported_capabilities')]
+
   let g:lsp_snippet_expand = [{ option -> vsnip#anonymous(option.snippet) }]
 endfunction
 
@@ -11,7 +15,7 @@ endfunction
 " get_supported_capabilities.
 "
 function! s:get_supported_capabilities(server_info) abort
-  let l:capabilities = lsp#default_get_supported_capabilities(a:server_info)
+  let l:capabilities = call(s:existing_capabilities_function[0], [a:server_info])
 
   if !has_key(l:capabilities, 'textDocument')
     let l:capabilities.textDocument = {}


### PR DESCRIPTION
To integrate with vim-lsp this plugin overwrites the default function for getting LSP capabilities to check for snippet capabilities. However when doing this, it first calls the default capabilities function before adding its own keys into the request. This caused any user-defined functions that overwrite the default to be ignored.  Instead, this plugin should use whatever is set as the global capabilities function value (which falls back to the default) to ensure that any user-defined functions aren't ignored